### PR TITLE
fix(rules): check children value instead of raw to take non HTML entities

### DIFF
--- a/src/rules/no-text-as-children.js
+++ b/src/rules/no-text-as-children.js
@@ -32,7 +32,7 @@ module.exports = {
       JSXElement(node) {
         node.children.forEach(child => {
           if (child.type === 'Literal') {
-            const text = child.raw.trim().replace('\\n', '');
+            const text = child.value.trim().replace('\\n', '');
             if (text.length && (!ignorePattern || !new RegExp(ignorePattern).test(text))) {
               context.report({
                 node: child,


### PR DESCRIPTION
Because `&nbsp;`was not interpret as space for example.