### PR TITLE
fix(no-text-as-attribute): allow undefined 'attributes' in config

### DIFF
--- a/src/rules/no-text-as-attribute.js
+++ b/src/rules/no-text-as-attribute.js
@@ -21,7 +21,7 @@ module.exports = {
   },
   create(context) {
     const [options] = context.options;
-    const { attributes } = options || {};
+    const { attributes = [] } = options || {};
 
     return {
       JSXAttribute(node) {

--- a/tests/src/rules/no-text-as-attribute.spec.js
+++ b/tests/src/rules/no-text-as-attribute.spec.js
@@ -40,6 +40,18 @@ ruleTester.run('m6web-i18n/no-text-as-attribute', rule, {
       settings,
       options,
     },
+    {
+      code: '<div alt="without option">{t("basic")}</div>',
+      parserOptions,
+      settings,
+      options: [],
+    },
+    {
+      code: '<div alt="empty option">{t("basic")}</div>',
+      parserOptions,
+      settings,
+      options: [{}],
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
close #13 