### PR TITLE
Allow custom (or none) keySeparator.

### DIFF
--- a/src/rules/interpolation-data.js
+++ b/src/rules/interpolation-data.js
@@ -48,7 +48,7 @@ module.exports = {
           }
 
           const isPluralized = !!countNode && Array.isArray(config.pluralizedKeys);
-          const translateValue = get(translation, key);
+          const translateValue = get(translation, key, config.keySeparator);
           const [{ interpolationPattern }] = context.options;
           const interpolationTester = new RegExp(interpolationPattern);
 

--- a/src/rules/no-unknown-key.js
+++ b/src/rules/no-unknown-key.js
@@ -42,7 +42,7 @@ module.exports = langsKey => ({
             return;
           }
 
-          if (typeof countNode === 'undefined' && !has(translation, key)) {
+          if (typeof countNode === 'undefined' && !has(translation, key, config.keySeparator)) {
             context.report({
               node,
               severity: 2,
@@ -52,7 +52,7 @@ module.exports = langsKey => ({
             return;
           }
 
-          if (typeof countNode === 'undefined' && has(translation, key) && typeof get(translation, key) !== 'string') {
+          if (typeof countNode === 'undefined' && has(translation, key, config.keySeparator) && typeof get(translation, key, config.keySeparator) !== 'string') {
             context.report({
               node,
               severity: 2,

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -9,9 +9,9 @@ const recursiveGet = (object, keys, index) => {
   return object[keys[index]] ? recursiveGet(object[keys[index]], keys, index + 1) : undefined;
 };
 
-exports.has = (object, key) => !!recursiveGet(object, key.split('.'), 0);
+exports.has = (object, key, separator = '.') => !!recursiveGet(object, key.split(separator), 0);
 
-exports.get = (object, key) => recursiveGet(object, key.split('.'), 0);
+exports.get = (object, key, separator = '.') => recursiveGet(object, key.split(separator), 0);
 
 exports.getKeyValue = key => {
   if (key.type === 'Literal') {

--- a/tests/src/utils/utils.spec.js
+++ b/tests/src/utils/utils.spec.js
@@ -22,6 +22,24 @@ describe('utils', () => {
     assert.ok(has(object, 'foo.bar'));
   });
 
+  it('should has key with no separator', () => {
+    const object = {
+      'foo.bar': 'foobar',
+    };
+
+    assert.ok(has(object, 'foo.bar', false));
+  });
+
+  it('should has key with custom separator', () => {
+    const object = {
+      foo: {
+        bar: 'foobar',
+      },
+    };
+
+    assert.ok(has(object, 'foo::bar', '::'));
+  });
+
   it('should getLangConfig', () => {
     const config = {
       foo: [


### PR DESCRIPTION
I use a flat resource file with english phrases as keys with i18next configured with `keySeparator: false`, and m6web-i18n linting did not work for keys containing periods.

This PR allows for `keySeparator: false` (or a different separator) in eslintrc settings for i18n as well.
